### PR TITLE
Return attributes in CAS2 serviceValidate

### DIFF
--- a/src/Http/Controllers/ValidateController.php
+++ b/src/Http/Controllers/ValidateController.php
@@ -102,7 +102,7 @@ class ValidateController extends Controller
 
     public function v2ServiceValidateAction(Request $request)
     {
-        return $this->casValidate($request, false, false);
+        return $this->casValidate($request, true, false);
     }
 
     public function v3ServiceValidateAction(Request $request)

--- a/tests/Http/Controllers/ValidateControllerTest.php
+++ b/tests/Http/Controllers/ValidateControllerTest.php
@@ -149,7 +149,7 @@ class ValidateControllerTest extends TestCase
             ->makePartial()
             ->shouldAllowMockingProtectedMethods()
             ->shouldReceive('casValidate')
-            ->with($request, false, false)
+            ->with($request, true, false)
             ->andReturn('casValidate called')
             ->once()
             ->getMock();


### PR DESCRIPTION
The current implementation of CAS2 `serviceValidate` endpoint doesn't return any attributes, which may be confusing for some clients using CAS2 endpoints and expecting the attributes.

Though [the protocol spec](https://apereo.github.io/cas/5.2.x/protocol/CAS-Protocol-Specification.html#255-attributes-cas-30) mentions "attributes" in CAS 3.0, the attribute format did exist in CAS Protocal 2.0 as some custom additions.

> Because the CAS 2.0 protocol provided no guidance on how to return or format attributes implementers were left to their own devices and have come up with numerous incompatible ways of formatting attribute elements. In phpCAS we currently support three different structures for user attributes: "Jasig-style", "RubyCAS-style", and "Name-Value-style"). See our test-case for examples of these formats: https://github.com/Jasig/phpCAS/blob/master/test/CAS/Tests/Cas20AttributesTest.php
>
> https://groups.google.com/forum/#!searchin/jasig-cas-dev/multi-valued$20attributes|sort:date/jasig-cas-dev/fJXthm4PqMY/mIMzDE0bHl0J

I agree that **newer clients should use the `p3/serviceValidate` endpoint to ensure a standard attribute format**. However, returning attributes on v2 endpoint (the p3 format in older "Jasig-style") does no harm because it's just "undefined", and may reduce some confusion. This is why we are making this pull request.

Any ideas are welcome.

*Reference: [attributes change related JIRA issues in CAS Protocal 3.0](https://issues.jasig.org/browse/CAS-1381?jql=project%20%3D%20CAS%20AND%20text%20~%20%22multi-valued%20attributes%22)*