### PR TITLE
Add multi-valued attribute support for XML

### DIFF
--- a/src/Responses/XmlAuthenticationSuccessResponse.php
+++ b/src/Responses/XmlAuthenticationSuccessResponse.php
@@ -49,8 +49,8 @@ class XmlAuthenticationSuccessResponse extends BaseXmlResponse implements Authen
         $this->removeByXPath($authNode, 'cas:attributes');
         $attributesNode = $authNode->addChild('cas:attributes');
         foreach ($attributes as $key => $value) {
-            $value_arr = (array) $value;
-            foreach($value_arr as $v){
+            $valueArr = (array) $value;
+            foreach($valueArr as $v){
                 $str = $this->stringify($v);
                 if (is_string($str)) {
                     $attributesNode->addChild('cas:'.$key, $str);

--- a/src/Responses/XmlAuthenticationSuccessResponse.php
+++ b/src/Responses/XmlAuthenticationSuccessResponse.php
@@ -49,9 +49,12 @@ class XmlAuthenticationSuccessResponse extends BaseXmlResponse implements Authen
         $this->removeByXPath($authNode, 'cas:attributes');
         $attributesNode = $authNode->addChild('cas:attributes');
         foreach ($attributes as $key => $value) {
-            $str = $this->stringify($value);
-            if (is_string($str)) {
-                $attributesNode->addChild('cas:'.$key, $str);
+            $value_arr = (array) $value;
+            foreach($value_arr as $v){
+                $str = $this->stringify($v);
+                if (is_string($str)) {
+                    $attributesNode->addChild('cas:'.$key, $str);
+                }
             }
         }
 

--- a/tests/Responses/JsonAuthenticationSuccessResponseTest.php
+++ b/tests/Responses/JsonAuthenticationSuccessResponseTest.php
@@ -68,6 +68,15 @@ class JsonAuthenticationSuccessResponseTest extends TestCase
         $this->assertEquals(['serviceResponse' => ['authenticationSuccess' => ['attributes' => $attr2]]], $data);
     }
 
+    public function testSetMultiValuedAttributes()
+    {
+        $resp  = new JsonAuthenticationSuccessResponse();
+        $attr1 = ['key1' => ['value1', 'value2']];
+        $resp->setAttributes($attr1);
+        $data = $this->getData($resp);
+        $this->assertEquals(['serviceResponse' => ['authenticationSuccess' => ['attributes' => $attr1]]], $data);
+    }
+
     protected function getData(JsonAuthenticationSuccessResponse $resp)
     {
         $property = self::getNonPublicProperty($resp, 'data');

--- a/tests/Responses/XmlAuthenticationSuccessResponseTest.php
+++ b/tests/Responses/XmlAuthenticationSuccessResponseTest.php
@@ -54,12 +54,7 @@ class XmlAuthenticationSuccessResponseTest extends TestCase
 
     public function testSetAttributes()
     {
-        $resp    = Mockery::mock(XmlAuthenticationSuccessResponse::class, [])
-            ->makePartial()
-            ->shouldAllowMockingProtectedMethods()
-            ->shouldReceive('stringify')
-            ->andReturn('string')
-            ->getMock();
+        $resp    = new XmlAuthenticationSuccessResponse();
         $content = $this->getXML($resp);
         $this->assertNotContains('cas:attributes', $content);
 
@@ -74,6 +69,19 @@ class XmlAuthenticationSuccessResponseTest extends TestCase
         $this->assertNotContains('cas:key1', $content);
         $this->assertContains('cas:key2', $content);
         $this->assertContains('cas:key3', $content);
+    }
+
+    public function testSetMultiValuedAttributes()
+    {
+        $resp    = new XmlAuthenticationSuccessResponse();
+        $content = $this->getXML($resp);
+        $this->assertNotContains('cas:attributes', $content);
+
+        $resp->setAttributes(['key1' => ['value1', 'value2']]);
+        $content = $this->getXML($resp);
+        $this->assertContains('cas:attributes', $content);
+        $this->assertContains('<cas:key1>value1</cas:key1>', $content);
+        $this->assertContains('<cas:key1>value2</cas:key1>', $content);
     }
 
     public function testSetProxyGrantingTicket()


### PR DESCRIPTION
According to [CAS 3.0 specs](https://apereo.github.io/cas/5.2.x/protocol/CAS-Protocol-Specification.html#257-example-response-with-custom-attributes), multi-valued attribute output should be supported like:
```xml
        <cas:affiliation>staff</cas:affiliation>
        <cas:affiliation>faculty</cas:affiliation>
```
This patch fixed this. JSON already supports this correctly.

*Reference: [CAS-703](https://issues.jasig.org/browse/CAS-703), [CAS-1283](https://issues.jasig.org/browse/CAS-1283)*