### PR TITLE
add routes for odd external service

### DIFF
--- a/src/Http/routes.php
+++ b/src/Http/routes.php
@@ -17,9 +17,9 @@ Route::group(
         Route::get('login', 'SecurityController@showLogin')->name($p.'login.get');
         Route::post('login', 'SecurityController@login')->name($p.'login.post');
         Route::get('logout', 'SecurityController@logout')->name($p.'logout')->middleware($auth);
-        Route::get('p3/login', 'SecurityController@showLogin')->name($p.'login.get');
-        Route::post('p3/login', 'SecurityController@login')->name($p.'login.post');
-        Route::get('p3/logout', 'SecurityController@logout')->name($p.'logout')->middleware($auth);
+        Route::get('p3/login', 'SecurityController@showLogin')->name($p.'v3.login.get');
+        Route::post('p3/login', 'SecurityController@login')->name($p.'v3.login.post');
+        Route::get('p3/logout', 'SecurityController@logout')->name($p.'v3.logout')->middleware($auth);
         Route::any('validate', 'ValidateController@v1ValidateAction')->name($p.'v1.validate');
         Route::any('serviceValidate', 'ValidateController@v2ServiceValidateAction')->name($p.'v2.validate.service');
         Route::any('proxyValidate', 'ValidateController@v2ProxyValidateAction')->name($p.'v2.validate.proxy');

--- a/src/Http/routes.php
+++ b/src/Http/routes.php
@@ -17,6 +17,9 @@ Route::group(
         Route::get('login', 'SecurityController@showLogin')->name($p.'login.get');
         Route::post('login', 'SecurityController@login')->name($p.'login.post');
         Route::get('logout', 'SecurityController@logout')->name($p.'logout')->middleware($auth);
+        Route::get('p3/login', 'SecurityController@showLogin')->name($p.'login.get');
+        Route::post('p3/login', 'SecurityController@login')->name($p.'login.post');
+        Route::get('p3/logout', 'SecurityController@logout')->name($p.'logout')->middleware($auth);
         Route::any('validate', 'ValidateController@v1ValidateAction')->name($p.'v1.validate');
         Route::any('serviceValidate', 'ValidateController@v2ServiceValidateAction')->name($p.'v2.validate.service');
         Route::any('proxyValidate', 'ValidateController@v2ProxyValidateAction')->name($p.'v2.validate.proxy');


### PR DESCRIPTION
One of the external sources we connect to oddly hits p3/login and p3/logout when using CAS protocol 3.0.  Our java cas 4.2 installation is currently handling these routes, so I assume it should be supported.